### PR TITLE
1.5.4 updates.

### DIFF
--- a/pytorch_common/config.py
+++ b/pytorch_common/config.py
@@ -321,3 +321,21 @@ def check_and_set_misc_config(config: _Config) -> None:
     # Used for dataloader sampling
     config.num_batches = config.get("num_batches", None)
     config.percentage = config.get("percentage", None)
+
+    # Check correct params for sample weighting
+    error_message = (
+        "The `reduction` ({reduction}) for the loss criterion must "
+        "be set to 'none' if you want to use sample weighting."
+    )
+    if config.sample_weighting_train:
+        assert config.loss_kwargs["reduction_train"] == "none", error_message.format(
+            reduction=config.loss_kwargs.get("reduction_train", "mean")
+        )
+    if config.sample_weighting_eval:
+        assert config.loss_kwargs["reduction_val"] == "none", error_message.format(
+            reduction=config.loss_kwargs.get("reduction_val", "mean")
+        )
+        logger.warning(
+            "You have turned on sample weights for evaluation (`sample_weighting_eval`). Most use "
+            "cases don't need this parameter -- make sure you have a strong argument for using it."
+        )

--- a/pytorch_common/configs/config.yaml
+++ b/pytorch_common/configs/config.yaml
@@ -34,6 +34,10 @@ loss_criterion: cross-entropy
   # alpha: 0.7
   # gamma: 0.2
 
+# Set to True if you want to use sample weights in training and/or evaluation
+sample_weighting_train: False
+sample_weighting_eval: False
+
 # Evaluation criteria
 eval_criteria:
   - "accuracy"

--- a/pytorch_common/types.py
+++ b/pytorch_common/types.py
@@ -29,9 +29,6 @@ __all__ = [
     "_TensorOrTensors",
     "_ModelOrModels",
     "_EvalCriterionOrCriteria",
-    "_TrainResult",
-    "_EvalResult",
-    "_TestResult",
     "_DecoupleFnTrain",
     "_DecoupleFnTest",
     "_DecoupleFn",
@@ -49,10 +46,6 @@ _TensorsOrArrays = Union[Iterable[torch.Tensor], Iterable[np.ndarray]]
 _TensorOrTensors = Union[torch.Tensor, Iterable[torch.Tensor]]
 _ModelOrModels = Union[nn.Module, Iterable[nn.Module]]
 _EvalCriterionOrCriteria = Union[Dict[str, Callable], Dict[str, Iterable[Callable]]]
-
-_TrainResult = List[float]
-_EvalResult = Tuple[List[float], Dict[str, float], torch.Tensor, torch.Tensor]
-_TestResult = Iterable[torch.Tensor]
 
 _DecoupleFnTrain = Callable[[_Batch], Tuple[_Batch]]
 _DecoupleFnTest = Callable[[_Batch], _Batch]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     # Application info
     name="pytorch_common",
-    version="1.5.3",
+    version="1.5.4",
     author="Mihir Rana",
     author_email="ranamihir@gmail.com",
     description="Repo for common PyTorch code",
@@ -24,7 +24,7 @@ setup(
         "locket==0.2.0",
     ],
     # Optional dependencies
-    extras_require={"nlp": ["transformers>=4.15.0"]},  # for NLP related projects
+    extras_require={"nlp": ["transformers>=4.16.2"]},  # for NLP related projects
     # Add config and sql files to the package
     # https://python-packaging.readthedocs.io/en/latest/non-code-files.html
     include_package_data=True,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -59,11 +59,11 @@ class TestMetrics(unittest.TestCase):
                 }
                 if loss_criterion == "focal-loss":
                     # FocalLoss only compatible with binary classification
-                    self._test_error(self._get_loss_eval_criteria, dictionary, error=ValueError)
+                    self._test_error(self._get_loss_eval_criteria, ValueError, dictionary)
                 else:
                     # Param `multilabel_reduction` required for multilabel classification
                     if classification_type == "multilabel":
-                        self._test_error(self._get_loss_eval_criteria, dictionary, error=ValueError)
+                        self._test_error(self._get_loss_eval_criteria, ValueError, dictionary)
                         for key in ["loss_kwargs", "eval_criteria_kwargs"]:
                             dictionary[key] = {"multilabel_reduction": "mean"}
                     self._get_loss_eval_criteria(dictionary)
@@ -138,14 +138,14 @@ class TestMetrics(unittest.TestCase):
         for metric, value in eval_metrics.items():
             np.testing.assert_allclose(value, true_values[metric], atol=1e-3)
 
-    def _test_error(self, func: Callable[[Any], None], args, error=AssertionError) -> None:
+    def _test_error(self, func: Callable[[Any], None], error=AssertionError, *args, **kwargs) -> None:
         """
         Generic code to assert that `error`
         is raised when calling a function
-        `func` with arguments `args`.
+        `func` with arguments `args` and `kwargs`.
         """
         with self.assertRaises(error):
-            func(args)
+            func(*args, **kwargs)
 
     def _get_merged_dict(self, dictionary: Optional[Dict] = None) -> Dict:
         """


### PR DESCRIPTION
- [Breaking] `train_utils.perform_one_epoch()` now returns a dictionary instead of list.
- Model evaluation / prediction methods now accept `return_keys` as an argument to pre-specify what items are to be returned.
  - This results in huge memory advantages by not having to store unnecessary objects.
- Added option to only perform training without any evaluation, by simply not providing any validation dataloader / logger arguments.
  - [Breaking] As part of this change, for the sake of simplicity, the `ReduceLROnPlateau` scheduler is now no longer supported (which requires validation loss in order to take each step).
- Added feature to add sample weighting during training and evaluation.
- Added several unit tests in accordance with the aforementioned features.
- Several other time, memory, and logging improvements.